### PR TITLE
[feat/style] 테이블 CSS 스타일 제어 기능 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,6 +7,8 @@ import TableFooter from "./components/TableFooter";
 import AddSubRow from "./components/SubRowComponents/AddSubRow";
 import { ColumnDef, Row } from "@tanstack/react-table";
 
+import { HeaderOptionType } from "./type/type";
+
 export interface Example {
   No: number;
   firstName: string;
@@ -120,19 +122,41 @@ const columns: ColumnDef<Example>[] = [
   {
     accessorKey: "No",
     header: "No",
-    size: 100,
+    size: 10,
   },
   {
-    accessorKey: "firstName",
-    header: "First Name",
+    accessorKey: "name",
+    header: "Name",
     size: 200,
+    columns: [
+      {
+        accessorKey: "firstName",
+        header: "First Name",
+        size: 120,
+      },
+      {
+        accessorKey: "lastName",
+        header: "Last Name",
+        size: 120,
+      },
+    ],
   },
   {
     accessorKey: "add",
     header: "add",
-    size: 50,
+    size: 100,
   },
 ];
+
+const headerOption: HeaderOptionType[] = [
+  { accessorKey: "No", layer: 1, colSpan: 1, rowSpan: 2 },
+  { accessorKey: "name", layer: 1, colSpan: 2, rowSpan: 1 },
+  { accessorKey: "firstName", layer: 2, colSpan: 1, rowSpan: 1 },
+  { accessorKey: "lastName", layer: 2, colSpan: 1, rowSpan: 1 },
+  { accessorKey: "add", layer: 1, colSpan: 1, rowSpan: 2 },
+];
+
+import style from "./style.module.css";
 
 function App() {
   const { table, totalPageNum, pagination, setPagination } = useTable<Example>({
@@ -152,8 +176,18 @@ function App() {
         rowClickEvent={handleClickRow}
         useParentRowUi={true}
       >
-        <TableHeader table={table} />
-        <TableBody table={table} />
+        <TableHeader
+          table={table}
+          headerOptionType={headerOption}
+          className={style.tableHeader}
+        />
+        <TableBody
+          table={table}
+          style={{
+            border: "1px solid black",
+            textAlign: "center",
+          }}
+        />
       </TableProvider>
 
       <TableFooter

--- a/src/components/SubRowComponents/AddSubRow.tsx
+++ b/src/components/SubRowComponents/AddSubRow.tsx
@@ -20,13 +20,57 @@ const AddSubRow = ({ contents }: { contents: Array<object> }) => {
           display: "flex",
           flexDirection: "row",
           justifyContent: "center",
-          border: "1px solid black",
+
+          // padding: "2px",
         }}
         onClick={() => handleClickRow(index)}
       >
-        <div style={{ flex: "1 0 0" }}>{data.No}</div>
-        <div style={{ flex: "1 0 0" }}>{data.firstName}</div>
-        <div style={{ flex: "1 0 0" }}>{data.add}</div>
+        <div
+          style={{
+            flex: "1 0 0",
+            border: "1px solid black",
+            borderLeft: "none",
+            borderRight: "none",
+          }}
+        >
+          {data.No}
+        </div>
+        <div
+          style={{
+            flex: "1 0 0",
+            border: "1px solid black",
+            borderRight: "none",
+          }}
+        >
+          {data.firstName}
+        </div>
+        <div
+          style={{
+            flex: "1 0 0",
+            border: "1px solid black",
+            borderRight: "none",
+          }}
+        >
+          {data.add}
+        </div>
+        <div
+          style={{
+            flex: "1 0 0",
+            border: "1px solid black",
+            borderRight: "none",
+          }}
+        >
+          test
+        </div>
+        <div
+          style={{
+            flex: "1 0 0",
+            border: "1px solid black",
+            borderRight: "none",
+          }}
+        >
+          test
+        </div>
       </div>
     );
   });

--- a/src/components/TableBody/DefaultSubRow.tsx
+++ b/src/components/TableBody/DefaultSubRow.tsx
@@ -1,13 +1,16 @@
-import { useRef } from "react";
+import { CSSProperties, useRef } from "react";
 import { useTableContext } from "../../provider/TableProvider";
 
-const DefaultSubRow = ({
-  rowIndex,
-  contents,
-}: {
+interface DefaultSubRowProps {
   rowIndex: number;
   contents: Array<object>;
-}) => {
+  style?: CSSProperties;
+  className?: string;
+  subRowStyle?: CSSProperties;
+}
+
+const DefaultSubRow = (props: DefaultSubRowProps) => {
+  const { rowIndex, contents, style, className, subRowStyle } = props;
   const key = useRef(0);
   const { subRowClickEvent, subRowCellClickEvent } = useTableContext();
 
@@ -39,10 +42,11 @@ const DefaultSubRow = ({
           return (
             <td
               key={value}
+              style={{ ...style, ...subRowStyle }}
+              className={className}
               onClick={(e) =>
                 handleClickSubRowCell(e, cellIndex, rowIndex, itemIndex)
               }
-              style={{ padding: "8px", border: "1px solid #ddd" }}
             >
               {value}
             </td>

--- a/src/components/TableBody/TableBodyCell.tsx
+++ b/src/components/TableBody/TableBodyCell.tsx
@@ -1,6 +1,17 @@
+import { CSSProperties } from "react";
 import { Cell } from "@tanstack/react-table";
 
-const TableBodyCell = <T,>({ cell }: { cell: Cell<T, unknown> }) => {
+interface TableBodyCellProps<T> {
+  cell: Cell<T, unknown>;
+  style?: CSSProperties;
+  className?: string;
+}
+
+const TableBodyCell = <T,>({
+  cell,
+  style,
+  className,
+}: TableBodyCellProps<T>) => {
   // typeof fucntion 일 경우, columns 생성 시 custom 한 cell value 적용
   const cellValue =
     typeof cell.column.columnDef.cell === "function"
@@ -8,7 +19,7 @@ const TableBodyCell = <T,>({ cell }: { cell: Cell<T, unknown> }) => {
       : cell.getValue();
 
   return (
-    <td style={{ width: "inherit", padding: "8px", border: "1px solid #ddd" }}>
+    <td style={style} className={className}>
       {cellValue}
     </td>
   );

--- a/src/components/TableBody/TableBodyRow.tsx
+++ b/src/components/TableBody/TableBodyRow.tsx
@@ -1,9 +1,18 @@
+import { CSSProperties } from "react";
 import TableCell from "./TableBodyCell";
 import TableSubRow from "./TableSubRow";
 import { Row } from "@tanstack/react-table";
 import { useTableContext } from "../../provider/TableProvider";
 
-const TableBodyRow = <T,>({ row }: { row: Row<T> }) => {
+interface TableBodyRowProps<T> {
+  row: Row<T>;
+  style?: CSSProperties;
+  className?: string;
+  subRowStyle?: CSSProperties;
+}
+
+const TableBodyRow = <T,>(props: TableBodyRowProps<T>) => {
+  const { row, style, className, subRowStyle } = props;
   const cellGroup = row.getVisibleCells();
   const { rowClickEvent } = useTableContext();
 
@@ -16,14 +25,28 @@ const TableBodyRow = <T,>({ row }: { row: Row<T> }) => {
 
   return (
     <>
-      <tr key={row.id} onClick={handleRowClick} style={{ cursor: "pointer" }}>
+      <tr key={row.id} onClick={handleRowClick} style={{ cursor: "default" }}>
         {cellGroup.map((cell) => {
-          return <TableCell key={cell.id} cell={cell} />;
+          return (
+            <TableCell
+              key={cell.id}
+              cell={cell}
+              style={style}
+              className={className}
+            />
+          );
         })}
       </tr>
 
       {/* Sub Row */}
-      {row.getIsExpanded() && <TableSubRow row={row} />}
+      {row.getIsExpanded() && (
+        <TableSubRow
+          row={row}
+          style={style}
+          className={className}
+          subRowStyle={subRowStyle}
+        />
+      )}
     </>
   );
 };

--- a/src/components/TableBody/TableSubRow.tsx
+++ b/src/components/TableBody/TableSubRow.tsx
@@ -1,3 +1,4 @@
+import { CSSProperties } from "react";
 import { useAtomValue } from "jotai";
 import { useTableContext } from "../../provider/TableProvider";
 
@@ -6,7 +7,15 @@ import { Row } from "@tanstack/react-table";
 
 import { subRowContentsAtom } from "../../atom/subRowContentsAtom";
 
-const TableSubRow = <T,>({ row }: { row: Row<T> }) => {
+interface TableSubRowProps<T> {
+  row: Row<T>;
+  style?: CSSProperties;
+  className?: string;
+  subRowStyle?: CSSProperties;
+}
+
+const TableSubRow = <T,>(props: TableSubRowProps<T>) => {
+  const { row, style, className, subRowStyle } = props;
   const { SubRowComponent, useParentRowUi } = useTableContext();
 
   const subRowContents = useAtomValue(subRowContentsAtom);
@@ -15,7 +24,15 @@ const TableSubRow = <T,>({ row }: { row: Row<T> }) => {
   if (!contents) return;
 
   if (useParentRowUi) {
-    return <DefaultSubRow rowIndex={row.index} contents={contents} />;
+    return (
+      <DefaultSubRow
+        rowIndex={row.index}
+        contents={contents}
+        style={style}
+        className={className}
+        subRowStyle={subRowStyle}
+      />
+    );
   }
 
   if (SubRowComponent) {
@@ -23,7 +40,11 @@ const TableSubRow = <T,>({ row }: { row: Row<T> }) => {
       <tr>
         <td
           colSpan={row.getVisibleCells().length}
-          style={{ padding: "8px", border: "1px solid #ddd" }}
+          style={{
+            ...style,
+            padding: 0,
+          }}
+          className={className}
         >
           <SubRowComponent contents={contents} />
         </td>

--- a/src/components/TableBody/index.tsx
+++ b/src/components/TableBody/index.tsx
@@ -1,13 +1,25 @@
 import TableBodyRow from "./TableBodyRow";
 import { TableProps } from "../../type/type";
+import { CSSProperties } from "react";
 
-const TableBody = <T,>({ table }: TableProps<T>) => {
+interface TableBodyProps<T> extends TableProps<T> {
+  subRowStyle?: CSSProperties;
+}
+
+const TableBody = <T,>(props: TableBodyProps<T>) => {
+  const { table, style, className, subRowStyle } = props;
   const rows = table.getRowModel().rows;
 
   return (
     <tbody>
       {rows.map((row) => (
-        <TableBodyRow key={row.id} row={row} />
+        <TableBodyRow
+          key={row.id}
+          style={style}
+          className={className}
+          row={row}
+          subRowStyle={subRowStyle}
+        />
       ))}
     </tbody>
   );

--- a/src/components/TableContainer/DefaultTableContainer.tsx
+++ b/src/components/TableContainer/DefaultTableContainer.tsx
@@ -5,8 +5,8 @@ const DefaultTableContainer = ({ children }: { children: ReactNode }) => {
     <table
       style={{
         width: "100%",
-        borderCollapse: "collapse", // 테두리 중복 방지
-        tableLayout: "fixed", // 열 크기를 고정
+        borderCollapse: "collapse",
+        tableLayout: "fixed",
       }}
     >
       {children}

--- a/src/components/TableHeader/TableHeaderCell.tsx
+++ b/src/components/TableHeader/TableHeaderCell.tsx
@@ -1,4 +1,4 @@
-import { ReactNode } from "react";
+import { ReactNode, CSSProperties } from "react";
 import { Header } from "@tanstack/react-table";
 import {
   handleClickHeaderForSorting,
@@ -7,9 +7,15 @@ import {
 
 interface TableHeaderCellProps<T> {
   header: Header<T, unknown>;
+  style?: CSSProperties;
+  className?: string;
 }
 
-const TableHeaderCell = <T,>({ header }: TableHeaderCellProps<T>) => {
+const TableHeaderCell = <T,>({
+  header,
+  style,
+  className,
+}: TableHeaderCellProps<T>) => {
   const headerName = header.column.columnDef.header as ReactNode;
   const sortingType = header.column.getIsSorted();
   const sortingTypeIcon = getSortingDirectionUi(sortingType);
@@ -17,17 +23,22 @@ const TableHeaderCell = <T,>({ header }: TableHeaderCellProps<T>) => {
   return (
     <th
       key={header.id}
-      colSpan={header.colSpan}
-      rowSpan={header.rowSpan}
+      className={className}
       style={{
         width: `${header.getSize()}px`,
-        textAlign: "center",
-        padding: "8px",
-        border: "1px solid #ddd",
+        ...style,
       }}
+      colSpan={header.colSpan}
+      rowSpan={header.rowSpan}
       onClick={() => handleClickHeaderForSorting(header)}
     >
-      <div style={{ display: "flex", justifyContent: "center", gap: "3px" }}>
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "center",
+          gap: "3px",
+        }}
+      >
         <span>{headerName}</span>
         <span style={{ cursor: "pointer" }}>{sortingTypeIcon}</span>
       </div>

--- a/src/components/TableHeader/TableHeaderRow.tsx
+++ b/src/components/TableHeader/TableHeaderRow.tsx
@@ -1,15 +1,27 @@
+import { CSSProperties } from "react";
 import { HeaderDataType } from "../../util/header.util";
 import TableHeaderCell from "./TableHeaderCell";
 
 interface TableHeaderRowProps<T> {
   headerGroup: HeaderDataType<T>;
+  style?: CSSProperties;
+  className?: string;
 }
 
-const TableHeaderRow = <T,>({ headerGroup }: TableHeaderRowProps<T>) => {
+const TableHeaderRow = <T,>({
+  headerGroup,
+  style,
+  className,
+}: TableHeaderRowProps<T>) => {
   return (
     <tr>
       {headerGroup.headers.map((header) => (
-        <TableHeaderCell key={header.id} header={header} />
+        <TableHeaderCell
+          key={header.id}
+          className={className}
+          style={style}
+          header={header}
+        />
       ))}
     </tr>
   );

--- a/src/components/TableHeader/index.tsx
+++ b/src/components/TableHeader/index.tsx
@@ -3,13 +3,19 @@ import { getHeader } from "../../util/header.util";
 
 import TableHeaderRow from "./TableHeaderRow";
 
-const TableHeader = <T,>({ table, headerOptionType }: TableProps<T>) => {
+const TableHeader = <T,>(props: TableProps<T>) => {
+  const { table, headerOptionType, style, className } = props;
   const headerGroups = getHeader({ table, headerOptionType });
 
   return (
-    <thead>
+    <thead style={style}>
       {headerGroups.map((headerGroup) => (
-        <TableHeaderRow key={headerGroup.depth} headerGroup={headerGroup} />
+        <TableHeaderRow
+          key={headerGroup.depth}
+          className={className}
+          style={style}
+          headerGroup={headerGroup}
+        />
       ))}
     </thead>
   );

--- a/src/style.module.css
+++ b/src/style.module.css
@@ -1,0 +1,7 @@
+.tableHeader {
+  text-align: center;
+  padding: 4px;
+  border: 1px solid black;
+  font-size: 11px;
+  background-color: rgba(0, 0, 0, 0.5);
+}

--- a/src/type/type.ts
+++ b/src/type/type.ts
@@ -1,3 +1,4 @@
+import { CSSProperties } from "react";
 import { Table } from "@tanstack/react-table";
 
 export interface HeaderOptionType {
@@ -9,4 +10,6 @@ export interface HeaderOptionType {
 export interface TableProps<T> {
   table: Table<T>;
   headerOptionType?: HeaderOptionType[];
+  style?: CSSProperties;
+  className?: string;
 }


### PR DESCRIPTION
## Result

- style 적용 예시 코드 & 적용된 UI
<img width="659" alt="스크린샷 2024-09-28 오후 11 58 45" src="https://github.com/user-attachments/assets/e1b9f5a2-53af-4887-b736-afc0dc491625">

<img width="1908" alt="스크린샷 2024-09-28 오후 11 56 24" src="https://github.com/user-attachments/assets/1a8a0c1b-6d72-4352-90ad-3727fcdcda37">


## Work list
- Table Header, Table Body 의 CSS 스타일을 제어할 수 있도록 기능 추가
- props를 전달하여 제어 가능하도록 구현하였으며, 인라인 스타일과 className 을 전달하여 제어할 수 있도록 구현함 
- Table Body의 경우 Sub Row는 다른 스타일을 적용하는 경우도 고려하여, subRowStyle props를 추가로 구현함


## Discussion