### PR TITLE
[feat] Table footer 관련 ui 및 세부 기능 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,6 +9,9 @@ import { HeaderOptionType } from "./type/type";
 import useSubRowContents from "./hook/useSubRowContents";
 import useSubRowExpand from "./hook/useSubRowExpand";
 
+import { TablePagination } from "./components/TableFooter/TablePagination";
+import { TablePageSizeSelect } from "./components/TableFooter/TablePageSizeSelect";
+
 export interface Example {
   No: number;
   firstName: string;
@@ -31,7 +34,7 @@ const columns: ColumnDef<Example>[] = [
   {
     accessorKey: "No",
     header: "No",
-    size: 10,
+    size: 20,
   },
   {
     accessorKey: "name",
@@ -157,13 +160,30 @@ function App() {
             },
           }}
         />
+        <TableFooter
+          totalPageNum={totalPageNum}
+          pagination={pagination}
+          setPagination={setPagination}
+        />
       </TableProvider>
 
-      <TableFooter
-        totalPageNum={totalPageNum}
-        pagination={pagination}
-        setPagination={setPagination}
-      />
+      <div
+        style={{
+          width: "100%",
+          display: "flex",
+          justifyContent: "space-between",
+        }}
+      >
+        <TablePageSizeSelect
+          pagination={pagination}
+          setPagination={setPagination}
+        />
+        <TablePagination
+          pagination={pagination}
+          setPagination={setPagination}
+          totalPageNum={totalPageNum}
+        />
+      </div>
     </>
   );
 }

--- a/src/components/TableContainer/TableContainer.tsx
+++ b/src/components/TableContainer/TableContainer.tsx
@@ -6,7 +6,6 @@ const TableContainer = ({ children }: { children: ReactNode }) => {
       style={{
         width: "100%",
         borderCollapse: "collapse",
-        tableLayout: "fixed",
       }}
     >
       {children}

--- a/src/components/TableFooter/TablePageSizeSelect.tsx
+++ b/src/components/TableFooter/TablePageSizeSelect.tsx
@@ -1,9 +1,6 @@
+import { Dispatch, SetStateAction, ChangeEvent, useLayoutEffect } from "react";
 import { PaginationState } from "@tanstack/react-table";
-import { Dispatch, SetStateAction, ChangeEvent } from "react";
-import {
-  checkDefaultSizeExist,
-  handleChangePageSize,
-} from "../../util/footer.util";
+import { getMedianIndexOfArray, changePageSize } from "../../util/footer.util";
 
 export interface TablePageSizeSelectProps {
   pageSizeList?: Array<number>;
@@ -19,17 +16,21 @@ export const TablePageSizeSelect = (props: TablePageSizeSelectProps) => {
   } = props;
 
   const sizeList: Array<number> = pageSizeList;
-  checkDefaultSizeExist(sizeList, pagination.pageSize);
 
-  const handleSelectChange = (event: ChangeEvent<HTMLSelectElement>) => {
-    handleChangePageSize(event.target.value, setPagination);
+  const handleChangeOption = (event: ChangeEvent<HTMLSelectElement>) => {
+    changePageSize(event.target.value, setPagination);
   };
+
+  useLayoutEffect(function setInitPageSize() {
+    const initPageSize = pageSizeList[getMedianIndexOfArray(pageSizeList)];
+    setPagination({ ...pagination, pageSize: initPageSize });
+  }, []);
 
   return (
     <select
       id="pageSizeSelect"
       value={String(pagination.pageSize)}
-      onChange={handleSelectChange}
+      onChange={handleChangeOption}
     >
       {sizeList.map((size) => (
         <option key={size} value={size}>

--- a/src/components/TableFooter/TablePageSizeSelect.tsx
+++ b/src/components/TableFooter/TablePageSizeSelect.tsx
@@ -27,11 +27,7 @@ export const TablePageSizeSelect = (props: TablePageSizeSelectProps) => {
   }, []);
 
   return (
-    <select
-      id="pageSizeSelect"
-      value={String(pagination.pageSize)}
-      onChange={handleChangeOption}
-    >
+    <select value={String(pagination.pageSize)} onChange={handleChangeOption}>
       {sizeList.map((size) => (
         <option key={size} value={size}>
           {size}

--- a/src/components/TableFooter/index.tsx
+++ b/src/components/TableFooter/index.tsx
@@ -10,24 +10,31 @@ const TableFooter = (props: TableFooterProps) => {
   const { pageSizeList, totalPageNum, pagination, setPagination } = props;
 
   return (
-    <div
-      style={{
-        width: "100%",
-        display: "flex",
-        justifyContent: "space-between",
-      }}
-    >
-      <TablePageSizeSelect
-        pageSizeList={pageSizeList}
-        pagination={pagination}
-        setPagination={setPagination}
-      />
-      <TablePagination
-        totalPageNum={totalPageNum}
-        pagination={pagination}
-        setPagination={setPagination}
-      />
-    </div>
+    <tfoot>
+      <tr>
+        <td colSpan={100}>
+          <div
+            style={{
+              width: "100%",
+              marginTop: "2px",
+              display: "flex",
+              justifyContent: "space-between",
+            }}
+          >
+            <TablePageSizeSelect
+              pageSizeList={pageSizeList}
+              pagination={pagination}
+              setPagination={setPagination}
+            />
+            <TablePagination
+              totalPageNum={totalPageNum}
+              pagination={pagination}
+              setPagination={setPagination}
+            />
+          </div>
+        </td>
+      </tr>
+    </tfoot>
   );
 };
 export default TableFooter;

--- a/src/util/footer.util.ts
+++ b/src/util/footer.util.ts
@@ -3,18 +3,11 @@ import { Dispatch, SetStateAction } from "react";
 
 type SetPaginationType = Dispatch<SetStateAction<PaginationState>>;
 
-// 1) page size select
-export const checkDefaultSizeExist = (
-  sizeList: Array<number>,
-  defaulSize: number
-) => {
-  if (!sizeList.includes(defaulSize)) {
-    sizeList.push(defaulSize);
-    sizeList.sort((a, b) => a - b);
-  }
+export const getMedianIndexOfArray = (arr: number[]) => {
+  return Math.floor(arr.length / 2);
 };
 
-export const handleChangePageSize = (
+export const changePageSize = (
   pageSize: string | null,
   setPagination: SetPaginationType
 ) => {


### PR DESCRIPTION
## Result
- `TableFooter` (`pageSizeSelector` + `pagination`) 너비가 Table 전체 너비와 동일하게 설정되도록 ui 스타일 추가
- page size 초기 값 설정 관련 기능 추가 (size list 배열의 중앙 값이 init value 로 설정되도록 구현)

## Work list

## Discussion
