### PR TITLE
[feat] table layout 세부 조정용 props 추가 (table borderTop/Left)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -156,90 +156,6 @@ const dummyData: Array<Example> = [
   { No: 5, firstName: "kim", add: "-" },
   { No: 6, firstName: "kim", add: "-" },
   { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
-  { No: 1, firstName: "kim", add: "-" },
-  { No: 2, firstName: "kim", add: "-" },
-  { No: 3, firstName: "kim", add: "-" },
-  { No: 4, firstName: "kim", add: "-" },
-  { No: 5, firstName: "kim", add: "-" },
-  { No: 6, firstName: "kim", add: "-" },
-  { No: 7, firstName: "kim", add: "-" },
 ];
 
 const columns: ColumnDef<Example>[] = [
@@ -342,51 +258,100 @@ function App() {
   };
 
   return (
-    <>
-      <TableProvider
-        useParentRowUi={true}
-        subRowContents={subRowContents}
-        rowClickEvent={handleClickRow}
+    <div style={{ width: "100%", height: "100%" }}>
+      <nav
+        style={{
+          border: "1px solid black",
+          width: "100%",
+          height: "70px",
+        }}
       >
-        <TableHeader
-          table={table}
-          headerOption={headerOption}
-          style={{
-            textAlign: "center",
-            padding: "4px",
-            border: "1px solid black",
-            fontSize: "11px",
-            backgroundColor: "rgba(0, 0, 0, 0.5)",
-          }}
-        />
-        <TableBody
-          table={table}
-          style={{
-            border: "1px solid black",
-            textAlign: "center",
-          }}
-          subRowProps={{
-            expandState,
-            style: {
-              backgroundColor: "ivory",
-            },
-          }}
-        />
-        <TableFooter
-          totalPageNum={totalPageNum}
-          pagination={pagination}
-          setPagination={setPagination}
-        />
-      </TableProvider>
+        top nav
+      </nav>
 
       <div
         style={{
-          width: "100%",
           display: "flex",
-          justifyContent: "space-between",
+          width: "100%",
+          height: "calc(100% - 70px)",
         }}
-      ></div>
-    </>
+      >
+        <nav
+          style={{
+            width: "150px",
+            height: "100%",
+            border: "1px solid black",
+            borderTop: "none",
+          }}
+        >
+          left side nav
+        </nav>
+
+        <div
+          style={{
+            width: "100%",
+            overflow: "hidden",
+          }}
+        >
+          <div style={{ height: "calc(100% - 35px)", overflowY: "auto" }}>
+            <TableProvider
+              useParentRowUi={true}
+              subRowContents={subRowContents}
+              rowClickEvent={handleClickRow}
+              borderLeftNone={true}
+              borderTopNone={true}
+            >
+              <TableHeader
+                table={table}
+                headerOption={headerOption}
+                style={{
+                  textAlign: "center",
+                  padding: "4px",
+                  border: "1px solid black",
+                  fontSize: "11px",
+                  backgroundColor: "ivory",
+                }}
+              />
+              <TableBody
+                table={table}
+                style={{
+                  border: "1px solid black",
+                  textAlign: "center",
+                }}
+                subRowProps={{
+                  expandState,
+                  style: {
+                    backgroundColor: "ivory",
+                  },
+                }}
+              />
+            </TableProvider>
+          </div>
+
+          <TableFooter
+            pagination={pagination}
+            setPagination={setPagination}
+            totalPageNum={totalPageNum}
+            styles={{
+              containerStyle: {
+                padding: "2px 3px",
+                height: "100%",
+                border: "1px solid darkgray",
+                borderLeft: "none",
+              },
+              pageSizeSelectStyle: {
+                border: "none",
+              },
+              pageNumButtonStyle: {
+                border: "none",
+                backgroundColor: "transparent",
+                disabledArrowColor: "darkgray",
+              },
+            }}
+          />
+        </div>
+      </div>
+    </div>
   );
 }
 

--- a/src/components/TableBody/DefaultSubRow.tsx
+++ b/src/components/TableBody/DefaultSubRow.tsx
@@ -21,7 +21,8 @@ const DefaultSubRow = (props: DefaultSubRowProps) => {
   const { contents, style, subRowStyles } = props;
 
   const key = useRef(0);
-  const { subRowClickEvent, subRowCellClickEvent } = useTableContext();
+  const { subRowClickEvent, subRowCellClickEvent, borderLeftNone } =
+    useTableContext();
 
   const handleClickSubRow = (
     rowIndex: number,
@@ -72,6 +73,8 @@ const DefaultSubRow = (props: DefaultSubRowProps) => {
                 ...style,
                 ...subRowStyles?.style,
                 backgroundColor: undefined,
+                height: "36px",
+                borderLeft: borderLeftNone ? "none" : style?.border,
               }}
               onClick={(e) => {
                 setClickedCellContent(value);

--- a/src/components/TableBody/TableBodyCell.tsx
+++ b/src/components/TableBody/TableBodyCell.tsx
@@ -16,7 +16,7 @@ const TableBodyCell = <T,>({
   rowIndex,
   style,
 }: TableBodyCellProps<T>) => {
-  const { cellClickEvent } = useTableContext();
+  const { cellClickEvent, borderLeftNone } = useTableContext();
 
   // If it's a function, apply custom cell value when generating columns
   const cellValue =
@@ -34,7 +34,12 @@ const TableBodyCell = <T,>({
 
   return (
     <td
-      style={{ ...style, backgroundColor: undefined }}
+      style={{
+        ...style,
+        backgroundColor: undefined,
+        height: "36px",
+        borderLeft: borderLeftNone ? "none" : style?.border,
+      }}
       onClick={handleClickCell}
     >
       {cellValue}

--- a/src/components/TableContainer/TableContainer.tsx
+++ b/src/components/TableContainer/TableContainer.tsx
@@ -5,6 +5,7 @@ const TableContainer = ({ children }: { children: ReactNode }) => {
     <table
       style={{
         width: "100%",
+        height: "fit-content",
         borderCollapse: "collapse",
       }}
     >

--- a/src/components/TableFooter/TablePageNumbers.tsx
+++ b/src/components/TableFooter/TablePageNumbers.tsx
@@ -25,6 +25,7 @@ export const TablePageNumbers = (props: TablePageNumberProps) => {
     justifyContent: "center",
     alignItems: "center",
     borderRadius: "3px",
+    cursor: "pointer",
 
     // style props
     color: style?.fontColor,

--- a/src/components/TableFooter/TablePageSizeSelect.tsx
+++ b/src/components/TableFooter/TablePageSizeSelect.tsx
@@ -53,6 +53,7 @@ export const TablePageSizeSelect = (props: TablePageSizeSelectProps) => {
 
     border: "none",
     outline: "none",
+    cursor: "pointer",
 
     // style props
     color: styles?.fontColor,

--- a/src/components/TableFooter/TablePagination.tsx
+++ b/src/components/TableFooter/TablePagination.tsx
@@ -11,6 +11,7 @@ export interface PageButtonStyleProps {
 
   selectedNumberButtonColor?: string;
   disabledArrowButtonColor?: string;
+  disabledArrowColor?: string;
 }
 
 export interface TablePaginationProps {
@@ -35,9 +36,9 @@ export const TablePagination = (props: TablePaginationProps) => {
     justifyContent: "center",
     alignItems: "center",
     borderRadius: "3px",
+    cursor: "pointer",
 
     // style props
-    color: styles?.fontColor,
     border: styles?.border ? styles.border : "1px solid darkgray",
   };
 
@@ -58,6 +59,21 @@ export const TablePagination = (props: TablePaginationProps) => {
     return backgroundColor;
   };
 
+  // style props about arrow color
+  const getArrowColor = (isDisabled: boolean) => {
+    let color: string | undefined;
+
+    if (isDisabled) {
+      color = styles?.disabledArrowColor
+        ? styles.disabledArrowColor
+        : styles?.fontColor;
+    } else {
+      color = styles?.fontColor;
+    }
+
+    return color;
+  };
+
   return (
     <div
       style={{
@@ -75,7 +91,10 @@ export const TablePagination = (props: TablePaginationProps) => {
         }}
         onClick={() => handleClickPageButton(pagination.pageIndex)}
       >
-        <svg viewBox="0 0 16 16" fill={styles?.fontColor}>
+        <svg
+          viewBox="0 0 16 16"
+          fill={getArrowColor(pagination.pageIndex === 0)}
+        >
           <path d="M7.219 8l3.3 3.3-.943.943L5.333 8l4.243-4.243.943.943-3.3 3.3z"></path>
         </svg>
       </button>
@@ -99,7 +118,10 @@ export const TablePagination = (props: TablePaginationProps) => {
         }}
         onClick={() => handleClickPageButton(pagination.pageIndex + 2)}
       >
-        <svg viewBox="0 0 16 16" fill={styles?.fontColor}>
+        <svg
+          viewBox="0 0 16 16"
+          fill={getArrowColor(pagination.pageIndex === totalPageNum - 1)}
+        >
           <path d="M8.781 8l-3.3-3.3.943-.943L10.667 8l-4.243 4.243-.943-.943 3.3-3.3z" />
         </svg>
       </button>

--- a/src/components/TableFooter/index.tsx
+++ b/src/components/TableFooter/index.tsx
@@ -1,4 +1,4 @@
-import { Dispatch, SetStateAction } from "react";
+import { CSSProperties, Dispatch, SetStateAction } from "react";
 import { PaginationState } from "@tanstack/react-table";
 import {
   TablePageSizeSelect,
@@ -13,6 +13,7 @@ interface TableFooterProps {
 
   pageSizeList?: Array<number>;
   styles?: {
+    containerStyle?: CSSProperties;
     pageNumButtonStyle?: PageButtonStyleProps;
     pageSizeSelectStyle?: PageSelectStyleProps;
   };
@@ -23,33 +24,27 @@ const TableFooter = (props: TableFooterProps) => {
     props;
 
   return (
-    <tfoot>
-      <tr>
-        <td colSpan={100}>
-          <div
-            style={{
-              width: "100%",
-              marginTop: "4px",
-              display: "flex",
-              justifyContent: "space-between",
-            }}
-          >
-            <TablePageSizeSelect
-              pageSizeList={pageSizeList}
-              pagination={pagination}
-              setPagination={setPagination}
-              styles={styles?.pageSizeSelectStyle}
-            />
-            <TablePagination
-              totalPageNum={totalPageNum}
-              pagination={pagination}
-              setPagination={setPagination}
-              styles={styles?.pageNumButtonStyle}
-            />
-          </div>
-        </td>
-      </tr>
-    </tfoot>
+    <div
+      style={{
+        width: "100%",
+        display: "flex",
+        justifyContent: "space-between",
+        ...styles?.containerStyle,
+      }}
+    >
+      <TablePageSizeSelect
+        pageSizeList={pageSizeList}
+        pagination={pagination}
+        setPagination={setPagination}
+        styles={styles?.pageSizeSelectStyle}
+      />
+      <TablePagination
+        totalPageNum={totalPageNum}
+        pagination={pagination}
+        setPagination={setPagination}
+        styles={styles?.pageNumButtonStyle}
+      />
+    </div>
   );
 };
 export default TableFooter;

--- a/src/components/TableHeader/TableHeaderCell.tsx
+++ b/src/components/TableHeader/TableHeaderCell.tsx
@@ -1,9 +1,7 @@
 import { ReactNode, CSSProperties } from "react";
+import { useTableContext } from "../../provider/TableProvider";
 import { Header } from "@tanstack/react-table";
-import {
-  handleClickHeaderForSorting,
-  getSortingDirectionUi,
-} from "../../util/header.util";
+import { handleClickHeaderForSorting } from "../../util/header.util";
 
 interface TableHeaderCellProps<T> {
   header: Header<T, unknown>;
@@ -12,8 +10,7 @@ interface TableHeaderCellProps<T> {
 
 const TableHeaderCell = <T,>({ header, style }: TableHeaderCellProps<T>) => {
   const headerName = header.column.columnDef.header as ReactNode;
-  const sortingType = header.column.getIsSorted();
-  const sortingTypeIcon = getSortingDirectionUi(sortingType);
+  const { borderTopNone } = useTableContext();
 
   return (
     <th
@@ -21,6 +18,9 @@ const TableHeaderCell = <T,>({ header, style }: TableHeaderCellProps<T>) => {
       style={{
         width: `${header.getSize()}px`,
         ...style,
+        height: "28px",
+        borderLeft: "none",
+        borderTop: borderTopNone ? "none" : style?.border,
       }}
       colSpan={header.colSpan}
       rowSpan={header.rowSpan}
@@ -30,11 +30,10 @@ const TableHeaderCell = <T,>({ header, style }: TableHeaderCellProps<T>) => {
         style={{
           display: "flex",
           justifyContent: "center",
-          gap: "3px",
+          alignItems: "center",
         }}
       >
-        <span>{headerName}</span>
-        <span style={{ cursor: "pointer" }}>{sortingTypeIcon}</span>
+        {headerName}
       </div>
     </th>
   );

--- a/src/components/TableHeader/index.tsx
+++ b/src/components/TableHeader/index.tsx
@@ -1,14 +1,21 @@
-import { TableProps } from "../../type/type";
+import { useTableContext } from "../../provider/TableProvider";
 import { getHeader } from "../../util/header.util";
-
 import TableHeaderRow from "./TableHeaderRow";
+import { TableProps } from "../../type/type";
 
 const TableHeader = <T,>(props: TableProps<T>) => {
   const { table, headerOption, style } = props;
+  const { borderTopNone } = useTableContext();
   const headerGroups = getHeader({ table, headerOption });
 
   return (
-    <thead style={style}>
+    <thead
+      style={{
+        ...style,
+        borderLeft: "none",
+        borderTop: borderTopNone ? "none" : style?.border,
+      }}
+    >
       {headerGroups.map((headerGroup) => (
         <TableHeaderRow
           key={headerGroup.depth}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,4 +1,5 @@
 import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
+import "./root.css";
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/provider/TableProvider.tsx
+++ b/src/provider/TableProvider.tsx
@@ -19,6 +19,8 @@ interface TableProviderProps {
     rowIndex,
     e,
   }: CellClickEventParam) => void;
+  borderLeftNone?: boolean;
+  borderTopNone?: boolean;
 }
 
 const TableContext = createContext<TableProviderProps | null>(null);
@@ -32,6 +34,8 @@ export const TableProvider = (props: PropsWithChildren<TableProviderProps>) => {
     cellClickEvent,
     subRowClickEvent,
     subRowCellClickEvent,
+    borderLeftNone,
+    borderTopNone,
   } = props;
 
   return (
@@ -44,6 +48,8 @@ export const TableProvider = (props: PropsWithChildren<TableProviderProps>) => {
         cellClickEvent,
         subRowClickEvent,
         subRowCellClickEvent,
+        borderLeftNone,
+        borderTopNone,
       }}
     >
       <TableContainer>{props.children}</TableContainer>

--- a/src/root.css
+++ b/src/root.css
@@ -1,0 +1,20 @@
+* {
+  box-sizing: border-box;
+}
+
+html {
+  width: 100vw;
+  height: 100vh;
+
+  margin: 0;
+  padding: 0;
+}
+
+body,
+#root {
+  width: 100%;
+  height: 100%;
+
+  margin: 0;
+  padding: 0;
+}


### PR DESCRIPTION
## Result
- table 전체 border 중 top, left 설정 여부를 제어할 수 있는 props 추가 (top nav, left nav와 겹칠 경우에 활용할 수 있도록)

## Work list
- table provider에 borderTopNone, borderLeftNone  props를 전달하여 border 제어할 수 있도록 구현

## Discussion
