### PR TITLE
[fix] rowSelectionType 중 grouped 관련 오류 수정

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rex-web-table",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rex-web-table",
-      "version": "1.0.17",
+      "version": "1.0.18",
       "dependencies": {
         "@tanstack/react-table": "^8.20.5"
       },

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "main": "dist/index.umd.js",
   "module": "dist/index.es.js",
   "types": "dist/index.d.ts",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "files": [
     "dist",
     "package.json",

--- a/src/components/TableBody/TableBodyRow.tsx
+++ b/src/components/TableBody/TableBodyRow.tsx
@@ -81,7 +81,7 @@ const TableBodyRow = <T,>(props: TableBodyRowProps<T>) => {
       // when selectionType grouped, set selected range
       if (
         rowSelectionType === "grouped" &&
-        selectedRowIndex &&
+        selectedRowIndex !== null &&
         groupSelectionRange
       ) {
         const isWithinRange =


### PR DESCRIPTION
## Result
- `grouped` 타입 선택 시, 0번 인덱스 행을 클릭했을 때 제대로 동작하지 않던 문제 해결

## Work list
- 분기 처리 관련 오류가 존재하여, 조건문 수정
- 기타 변경 사항 : 패키지 버전 수정

## Discussion
