### PR TITLE
feat: default row selection 기능 추가

### DIFF
--- a/README(en).md
+++ b/README(en).md
@@ -280,13 +280,14 @@ const headerOption: HeaderOptionType[] = [
 - **Important**: To apply **hoverColor** styles for **row** and **subRow**, you need to import CSS separately. Other styles except for **hoverColor** will work fine without importing the CSS.
 - The `props` required to call the component are listed below.
 
-| Props                 | Type                                            | Explain                                                                                                               | Required                                                                                |
-| --------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `table`               | `Table<TData>`                                  | The table instance returned by the `useTable` hook                                                                    | required                                                                                |
-| `interactiveStyles`   | `{ hoverColor: string; clickedColor: string; }` | Defines background colors for rows on hover and click events                                                          | `hoverColor` : optional, <br/> `clickedColor` : required when `rowSelectionType` is set |
-| `subRowProps`         | `object`                                        | Configuration for `subRow`                                                                                            | optional                                                                                |
-| `rowSelectionType`    | `"single"` or `"multiple"` or `"grouped"`       | Specifies the row selection type                                                                                      | optional                                                                                |
-| `groupSelectionRange` | `number`                                        | When `rowSelectionType` is set to `grouped`, specifies the range of additional rows to select around the selected one | required if `rowSelectionType` is `grouped`                                             |
+| Props                     | Type                                            | Explain                                                                                                               | Required                                                                                |
+| ------------------------- | ----------------------------------------------- | --------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `table`                   | `Table<TData>`                                  | The table instance returned by the `useTable` hook                                                                    | required                                                                                |
+| `interactiveStyles`       | `{ hoverColor: string; clickedColor: string; }` | Defines background colors for rows on hover and click events                                                          | `hoverColor` : optional, <br/> `clickedColor` : required when `rowSelectionType` is set |
+| `subRowProps`             | `object`                                        | Configuration for `subRow`                                                                                            | optional                                                                                |
+| `rowSelectionType`        | `"single"` or `"multiple"` or `"grouped"`       | Specifies the row selection type                                                                                      | optional                                                                                |
+| `defaultSelectedRowIndex` | `number`                                        | Sets the index of the row to be selected by default when `rowSelectionType` is set to `single`                        | Optional when `rowSelectionType` is `single`                                            |
+| `groupSelectionRange`     | `number`                                        | When `rowSelectionType` is set to `grouped`, specifies the range of additional rows to select around the selected one | required if `rowSelectionType` is `grouped`                                             |
 
 <br/>
 
@@ -308,25 +309,43 @@ import "rex-web-table/dist/index.css";
 /&gt;
 
 
-2) When `rowSelectionType` is set to "single" or "multiple"
+2) When rowSelectionType is "single":
 
-&lt;TableBody
+<TableBody
   table={table}
   style={{
-    // Sets the CSS properties for the table body
+    // Apply CSS properties to style the table body
     fontSize: "14px",
     border: "1px solid black",
     textAlign: "center",
   }}
   interactiveStyles={{
-    hoverColor: "white", // Sets background color when hovering over a row
-    clickedColor: "black", // `clickedColor` must be set when `rowSelectionType` is defined
+    hoverColor: "white", // Set background color when row is hovered
+    clickedColor: "black", // Set background color when row is clicked (as rowSelectionType is defined)
   }}
   rowSelectionType="single"
-/&gt;
+  defaultSelectedRowIndex={0} // (when rowSelectionType is single) set the 0th row as the default selected row
+/>;
+
+3) When rowSelectionType is "multiple":
+
+<TableBody
+  table={table}
+  style={{
+    // Apply CSS properties to style the table body
+    fontSize: "14px",
+    border: "1px solid black",
+    textAlign: "center",
+  }}
+  interactiveStyles={{
+    hoverColor: "white", // Set background color when row is hovered
+    clickedColor: "black", // Set background color when row is clicked (as rowSelectionType is defined)
+  }}
+  rowSelectionType="multiple"
+/>;
 
 
-3) When `rowSelectionType` is set to "grouped"
+4) When `rowSelectionType` is "grouped"
 
 &lt;TableBody
   table={table}

--- a/README.md
+++ b/README.md
@@ -283,13 +283,14 @@ const headerOption: HeaderOptionType[] = [
 - **중요**: **row**와 **subRow**의 **hoverColor** 스타일을 적용하려면 별도로 CSS import가 필요합니다. **hoverColor** 외의 다른 스타일은 CSS import 없이도 정상적으로 작동합니다.
 - 컴포넌트 호출 시 전달해야 하는 `props`는 아래와 같습니다.
 
-| Props                 | Type                                            | Explain                                                                                                            | Required                                                                                |
-| --------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
-| `table`               | `Table<TData>`                                  | `useTable` 훅이 반환하는 테이블 데이터 인스턴스                                                                    | required                                                                                |
-| `interactiveStyles`   | `{ hoverColor: string; clickedColor: string; }` | 테이블 행의 마우스 hover 시와 클릭 시 배경색 지정                                                                  | `hoverColor` : optional, <br/> `clickedColor` : `rowSelectionType`이 설정된 경우에 필수 |
-| `subRowProps`         | `object`                                        | `subRow` 관련 설정                                                                                                 | optional                                                                                |
-| `rowSelectionType`    | `"single"` or `"multiple"` or `"grouped"`       | 행 선택 타입을 설정                                                                                                | optional                                                                                |
-| `groupSelectionRange` | `number`                                        | `rowSelectionType`이 `grouped`일 때, 그룹 선택 범위를 설정합니다. (선택한 행 기준, `range` 만큼 위/아래 추가 선택) | `rowSelectionType`이 `grouped`일 때 필수                                                |
+| Props                     | Type                                            | Explain                                                                                                            | Required                                                                                |
+| ------------------------- | ----------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------- |
+| `table`                   | `Table<TData>`                                  | `useTable` 훅이 반환하는 테이블 데이터 인스턴스                                                                    | required                                                                                |
+| `interactiveStyles`       | `{ hoverColor: string; clickedColor: string; }` | 테이블 행의 마우스 hover 시와 클릭 시 배경색 지정                                                                  | `hoverColor` : optional, <br/> `clickedColor` : `rowSelectionType`이 설정된 경우에 필수 |
+| `subRowProps`             | `object`                                        | `subRow` 관련 설정                                                                                                 | optional                                                                                |
+| `rowSelectionType`        | `"single"` or `"multiple"` or `"grouped"`       | 행 선택 타입을 설정                                                                                                | optional                                                                                |
+| `defaultSelectedRowIndex` | `number`                                        | `rowSelectionType` 이 `single` 일 때, 기본 값으로 선택될 행의 인덱스를 설정합니다.                                 | `rowSelectionType`이 `single`일 때 optional                                             |
+| `groupSelectionRange`     | `number`                                        | `rowSelectionType`이 `grouped`일 때, 그룹 선택 범위를 설정합니다. (선택한 행 기준, `range` 만큼 위/아래 추가 선택) | `rowSelectionType`이 `grouped`일 때 필수                                                |
 
 <br/>
 
@@ -311,7 +312,7 @@ import "rex-web-table/dist/index.css";
 />;
 
 
-2) rowSelectionType이 "single" 혹은 "multiple"인 경우
+2) rowSelectionType이 "single"인 경우
 
 <TableBody
   table={table}
@@ -326,10 +327,28 @@ import "rex-web-table/dist/index.css";
     clickedColor: "black", // rowSelectionType이 설정되었으므로, clicekd Color 설정
   }}
   rowSelectionType="single"
+  defaultSelectedRowIndex={0} // (rowSelectionType이 single일 때) 0번째 행 기본 값으로 선택
+/>;
+
+3) rowSelectionType이 "multiple"인 경우
+
+<TableBody
+  table={table}
+  style={{
+    // 테이블 바디의 CSS 속성을 설정하여 스타일을 전달
+    fontSize: "14px",
+    border: "1px solid black",
+    textAlign: "center",
+  }}
+  interactiveStyles={{
+    hoverColor: "white", // 행 hover 시 배경색 설정
+    clickedColor: "black", // rowSelectionType이 설정되었으므로, clicekd Color 설정
+  }}
+  rowSelectionType="multiple"
 />;
 
 
-3) rowSelectionType이 "grouped"인 경우
+4) rowSelectionType이 "grouped"인 경우
 
 <TableBody
   table={table}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -184,6 +184,7 @@ function App() {
                 }}
               />
               <TableBody
+                rowSelectionType="single"
                 table={table}
                 style={{
                   fontSize: "14px",
@@ -192,7 +193,9 @@ function App() {
                 }}
                 interactiveStyles={{
                   hoverColor: testPage ? "black" : "darkblue",
+                  clickedColor: "red",
                 }}
+                defaultSelectedRowIndex={0}
                 subRowProps={{
                   expandState,
                   style: {

--- a/src/components/TableBody/index.tsx
+++ b/src/components/TableBody/index.tsx
@@ -12,12 +12,23 @@ interface BaseTableBodyProps<T> extends TableProps<T> {
   };
 }
 
-type SingleOrMultipleSelectionProps<T> = BaseTableBodyProps<T> & {
-  rowSelectionType: "single" | "multiple";
+type SingleSelectionProps<T> = BaseTableBodyProps<T> & {
+  rowSelectionType: "single";
   interactiveStyles: {
     hoverColor?: string;
     clickedColor: string;
   };
+  defaultSelectedRowIndex?: number;
+  groupSelectionRange?: never;
+};
+
+type MultipleSelectionProps<T> = BaseTableBodyProps<T> & {
+  rowSelectionType: "multiple";
+  interactiveStyles: {
+    hoverColor?: string;
+    clickedColor: string;
+  };
+  defaultSelectedRowIndex?: never;
   groupSelectionRange?: never;
 };
 
@@ -27,6 +38,7 @@ type GroupedSelectionProps<T> = BaseTableBodyProps<T> & {
     hoverColor?: string;
     clickedColor: string;
   };
+  defaultSelectedRowIndex?: never;
   groupSelectionRange: number;
 };
 
@@ -36,11 +48,13 @@ type NoSelectionProps<T> = BaseTableBodyProps<T> & {
     hoverColor?: string;
     clickedColor?: never;
   };
+  defaultSelectedRowIndex?: never;
   groupSelectionRange?: never;
 };
 
 type TableBodyProps<T> =
-  | SingleOrMultipleSelectionProps<T>
+  | SingleSelectionProps<T>
+  | MultipleSelectionProps<T>
   | GroupedSelectionProps<T>
   | NoSelectionProps<T>;
 
@@ -51,11 +65,14 @@ const TableBody = <T,>(props: TableBodyProps<T>) => {
     subRowProps,
     interactiveStyles,
     rowSelectionType,
+    defaultSelectedRowIndex,
     groupSelectionRange,
   } = props;
 
   const rows = table.getRowModel().rows;
-  const [selectedRowIndex, setSelectedRowIndex] = useState<null | number>(null);
+  const [selectedRowIndex, setSelectedRowIndex] = useState<null | number>(
+    defaultSelectedRowIndex !== undefined ? defaultSelectedRowIndex : null
+  );
 
   return (
     <tbody>


### PR DESCRIPTION
## Result
- `row selection type` 과 연관된 세부 `props` 추가

## Work list
- `row selection type`이 `single` 일 때, `default selected row index` 설정 가능하도록 기능 추가
(테이블 렌더링 시, 기본으로 선택되어있는 행 사전에 선택할 수 있도록 구현)
- `기타 작업` : 관련 문서화 추가

## Discussion
