### PR TITLE
Revert "release: peerDependencies 버전 수정 (React 19 버전 이상에서 활용 가능하도록)"

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,8 +21,8 @@
     "@tanstack/react-virtual": "^3.13.0"
   },
   "peerDependencies": {
-    "react": ">=18.0.0 || ^19.0.0",
-    "react-dom": ">=18.0.0 || ^19.0.0"
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.0",


### PR DESCRIPTION
Reverts novice1993/rex-web-table#34

- `chore:` 커밋으로 릴리즈가 트리거되지 않아 revert 후 `feat:` 커밋으로 다시 적용 예정
- 변경 내용은 그대로 유지될 예정이며, 목적은 `semantic-release` 자동 배포 트리거